### PR TITLE
closes #2 - update financial item when moving a contribution

### DIFF
--- a/CRM/LCD/MoveContrib/BAO/MoveContrib.php
+++ b/CRM/LCD/MoveContrib/BAO/MoveContrib.php
@@ -9,6 +9,15 @@ class CRM_LCD_MoveContrib_BAO_MoveContrib {
     $id = array('contribution' => $params['contribution_id']);
     $contribution = CRM_Contribute_BAO_Contribution::create($params, $id);
 
+    // Update the financial items' contact IDs as well.
+    $fiSql = "UPDATE civicrm_financial_item cfi
+    JOIN civicrm_entity_financial_trxn cefti ON cefti.entity_id = cfi.id
+    JOIN civicrm_financial_trxn cft ON cefti.entity_table = 'civicrm_financial_item' AND cft.id = cefti.financial_trxn_id
+    JOIN civicrm_entity_financial_trxn ceftc ON ceftc.financial_trxn_id = cft.id
+    SET cfi.contact_id = {$params['change_contact_id']}
+    WHERE ceftc.entity_table = 'civicrm_contribution' AND ceftc.entity_id = {$params['contribution_id']}";
+    CRM_Core_DAO::executeQuery($fiSql);
+
     // record activity for moving contribution
     if ($contribution) {
       $subject = "Contribution #{$params['contribution_id']} Moved";


### PR DESCRIPTION
Hey Brian,

I got bit by #2 again today so I decided to write my own fix.  I looked at the `CRM_Dedupe_Merger` code and established that it really doesn't do anything fancier than update the old contact ID with a new contact ID with direct SQL, so that's what I did here as well.