### PR TITLE
Civix upgrade, other housekeeping updates

### DIFF
--- a/CRM/LCD/MoveContrib/Form/MoveContrib.php
+++ b/CRM/LCD/MoveContrib/Form/MoveContrib.php
@@ -15,12 +15,12 @@ class CRM_LCD_MoveContrib_Form_MoveContrib extends CRM_Core_Form {
   public function preProcess() {
     //check for delete
     if (!CRM_Core_Permission::checkActionPermission('CiviContribute', CRM_Core_Action::UPDATE)) {
-      CRM_Core_Error::fatal(ts('You do not have permission to access this page.'));
+      CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
     }
     parent::preProcess();
   }
 
-  public function buildQuickForm() {
+  public function buildQuickForm(): void {
     $this->_contributionId = CRM_Utils_Request::retrieve('id', 'Positive', $this);
 
     $this->_contactId = civicrm_api3('contribution', 'getvalue', array(

--- a/CRM/LCD/MoveContrib/Form/MoveContrib.php
+++ b/CRM/LCD/MoveContrib/Form/MoveContrib.php
@@ -12,7 +12,7 @@ class CRM_LCD_MoveContrib_Form_MoveContrib extends CRM_Core_Form {
   /**
    * check permissions
    */
-  public function preProcess() {
+  public function preProcess(): void {
     //check for delete
     if (!CRM_Core_Permission::checkActionPermission('CiviContribute', CRM_Core_Action::UPDATE)) {
       CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
@@ -20,47 +20,50 @@ class CRM_LCD_MoveContrib_Form_MoveContrib extends CRM_Core_Form {
     parent::preProcess();
   }
 
+  /**
+   * @throws \CRM_Core_Exception
+   */
   public function buildQuickForm(): void {
-    $this->_contributionId = CRM_Utils_Request::retrieve('id', 'Positive', $this);
+    $contributionID = CRM_Utils_Request::retrieve('id', 'Positive', $this);
 
-    $this->_contactId = civicrm_api3('contribution', 'getvalue', array(
-      'id' => $this->_contributionId,
+    $contactID = civicrm_api3('contribution', 'getvalue', [
+      'id' => $contributionID,
       'return' => 'contact_id',
-    ));
+    ]);
 
     //get current contact name.
-    $this->assign('currentContactName', CRM_Contact_BAO_Contact::displayName($this->_contactId));
+    $this->assign('currentContactName', CRM_Contact_BAO_Contact::displayName($contactID));
 
     $this->addEntityRef('change_contact_id', ts('Select Contact'));
-    $this->add('hidden', 'contact_id', '', array('id' => 'contact_id'));
-    $this->add('hidden', 'contribution_id', $this->_contributionId, array('id' => 'contribution_id'));
-    $this->add('hidden', 'current_contact_id', $this->_contactId, array('id' => 'current_contact_id'));
-    $this->assign('contactId', $this->_contactId);
+    $this->add('hidden', 'contact_id', '', ['id' => 'contact_id']);
+    $this->add('hidden', 'contribution_id', $contributionID, ['id' => 'contribution_id']);
+    $this->add('hidden', 'current_contact_id', $contactID, ['id' => 'current_contact_id']);
+    $this->assign('contactId', $contactID);
 
     // export form elements
     $this->assign('elementNames', $this->getRenderableElementNames());
 
-    $this->addButtons(array(
-      array(
+    $this->addButtons([
+      [
         'type' => 'submit',
         'name' => ts('Submit'),
         'isDefault' => TRUE,
-      ),
-    ));
+      ],
+    ]);
 
     parent::buildQuickForm();
   }
 
-  public function postProcess() {
+  public function postProcess(): void {
     $values = $this->exportValues();
     //Civi::log()->debug('postProcess', array('values' => $values));
 
-    $params = array(
+    $params = [
       'change_contact_id' => $values['change_contact_id'],
       'contact_id' => $values['change_contact_id'],
       'contribution_id' => $values['contribution_id'],
       'current_contact_id' => $values['current_contact_id'],
-    );
+    ];
 
     $result = CRM_LCD_MoveContrib_BAO_MoveContrib::moveContribution($params);
 
@@ -79,12 +82,12 @@ class CRM_LCD_MoveContrib_Form_MoveContrib extends CRM_Core_Form {
    *
    * @return array (string)
    */
-  public function getRenderableElementNames() {
+  public function getRenderableElementNames(): array {
     // The _elements list includes some items which should not be
     // auto-rendered in the loop -- such as "qfKey" and "buttons".  These
     // items don't have labels.  We'll identify renderable by filtering on
     // the 'label'.
-    $elementNames = array();
+    $elementNames = [];
     foreach ($this->_elements as $element) {
       /** @var HTML_QuickForm_Element $element */
       $label = $element->getLabel();
@@ -94,4 +97,5 @@ class CRM_LCD_MoveContrib_Form_MoveContrib extends CRM_Core_Form {
     }
     return $elementNames;
   }
+
 }

--- a/CRM/LCD/MoveContrib/Form/Task.php
+++ b/CRM/LCD/MoveContrib/Form/Task.php
@@ -41,10 +41,10 @@ class CRM_LCD_MoveContrib_Form_Task extends CRM_Contribute_Form_Task {
   /**
    * Build all the data structures needed to build the form.
    */
-  public function preProcess() {
+  public function preProcess(): void {
     //check for delete
     if (!CRM_Core_Permission::checkActionPermission('CiviContribute', CRM_Core_Action::UPDATE)) {
-      CRM_Core_Error::fatal(ts('You do not have permission to access this page.'));
+      CRM_Core_Error::statusBounce(ts('You do not have permission to access this page.'));
     }
     parent::preProcess();
   }
@@ -52,7 +52,7 @@ class CRM_LCD_MoveContrib_Form_Task extends CRM_Contribute_Form_Task {
   /**
    * Build the form object.
    */
-  public function buildQuickForm() {
+  public function buildQuickForm(): void {
     $this->addEntityRef('change_contact_id', ts('Select Contact'));
     $count = count($this->_contributionIds);
     $this->assign('count', $count);
@@ -60,13 +60,13 @@ class CRM_LCD_MoveContrib_Form_Task extends CRM_Contribute_Form_Task {
     // export form elements
     $this->assign('elementNames', $this->getRenderableElementNames());
 
-    $this->addButtons(array(
-      array(
+    $this->addButtons([
+      [
         'type' => 'submit',
         'name' => ts('Submit'),
         'isDefault' => TRUE,
-      ),
-    ));
+      ],
+    ]);
 
     parent::buildQuickForm();
   }
@@ -74,26 +74,27 @@ class CRM_LCD_MoveContrib_Form_Task extends CRM_Contribute_Form_Task {
   /**
    * Process the form after the input has been submitted and validated.
    */
-  public function postProcess() {
+  public function postProcess(): void {
     $moved = $failed = 0;
     $values = $this->exportValues();
     //Civi::log()->debug('postProcess', array('values' => $values));
 
     foreach ($this->_contributionIds as $contributionId) {
       try {
-        $currentContactId = civicrm_api3('contribution', 'getvalue', array(
+        $currentContactId = civicrm_api3('Contribution', 'getvalue', [
           'id' => $contributionId,
           'return' => 'contact_id',
-        ));
+        ]);
       }
-      catch (CiviCRM_API3_Exception $e) {}
+      catch (CiviCRM_API3_Exception $e) {
+      }
 
-      $params = array(
+      $params = [
         'change_contact_id' => $values['change_contact_id'],
         'contact_id' => $values['change_contact_id'],
         'contribution_id' => $contributionId,
         'current_contact_id' => $currentContactId,
-      );
+      ];
 
       if (CRM_LCD_MoveContrib_BAO_MoveContrib::moveContribution($params)) {
         $moved++;
@@ -104,17 +105,17 @@ class CRM_LCD_MoveContrib_Form_Task extends CRM_Contribute_Form_Task {
     }
 
     if ($moved) {
-      CRM_Core_Session::setStatus(ts('%count contribution moved.', array(
+      CRM_Core_Session::setStatus(ts('%count contribution moved.', [
         'plural' => '%count contributions moved.',
-        'count' => $moved
-      )), ts('Moved'), 'success');
+        'count' => $moved,
+      ]), ts('Moved'), 'success');
     }
 
     if ($failed) {
-      CRM_Core_Session::setStatus(ts('1 could not be moved.', array(
+      CRM_Core_Session::setStatus(ts('1 could not be moved.', [
         'plural' => '%count could not be moved.',
-        'count' => $failed
-      )), ts('Error'), 'error');
+        'count' => $failed,
+      ]), ts('Error'), 'error');
     }
 
     parent::postProcess();
@@ -128,12 +129,12 @@ class CRM_LCD_MoveContrib_Form_Task extends CRM_Contribute_Form_Task {
    *
    * @return array (string)
    */
-  public function getRenderableElementNames() {
+  public function getRenderableElementNames(): array {
     // The _elements list includes some items which should not be
     // auto-rendered in the loop -- such as "qfKey" and "buttons".  These
     // items don't have labels.  We'll identify renderable by filtering on
     // the 'label'.
-    $elementNames = array();
+    $elementNames = [];
     foreach ($this->_elements as $element) {
       /** @var HTML_QuickForm_Element $element */
       $label = $element->getLabel();
@@ -143,4 +144,5 @@ class CRM_LCD_MoveContrib_Form_Task extends CRM_Contribute_Form_Task {
     }
     return $elementNames;
   }
+
 }

--- a/info.xml
+++ b/info.xml
@@ -26,7 +26,7 @@
   </civix>
   <mixins>
     <mixin>menu-xml@1.0.0</mixin>
-    <mixin>smarty-v2@1.0.1</mixin>
+    <mixin>smarty-v2@1.0.0</mixin>
   </mixins>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/movecontrib.php
+++ b/movecontrib.php
@@ -21,44 +21,12 @@ function movecontrib_civicrm_install() {
 }
 
 /**
- * Implements hook_civicrm_uninstall().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
- */
-function movecontrib_civicrm_uninstall() {
-}
-
-/**
  * Implements hook_civicrm_enable().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
  */
 function movecontrib_civicrm_enable() {
   _movecontrib_civix_civicrm_enable();
-}
-
-/**
- * Implements hook_civicrm_disable().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
- */
-function movecontrib_civicrm_disable() {
-}
-
-/**
- * Implements hook_civicrm_upgrade().
- *
- * @param $op string, the type of operation being performed; 'check' or 'enqueue'
- * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
- *
- * @return mixed
- *   Based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *                for 'enqueue', returns void
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
- */
-function movecontrib_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-  return;
 }
 
 function movecontrib_civicrm_searchColumns($objectName, &$headers, &$rows, &$selector) {
@@ -109,20 +77,4 @@ function movecontrib_civicrm_searchTasks($objectType, &$tasks) {
 function movecontrib_civicrm_permission(&$permissions) {
   $prefix = ts('Move Contributions') . ': '; // name of extension or module
   $permissions['allow Move Contribution'] = $prefix . ts('allow Move Contribution');
-}
-
-/**
- * Implements hook_civicrm_postInstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
- */
-function movecontrib_civicrm_postInstall() {
-}
-
-/**
- * Implements hook_civicrm_entityTypes().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
- */
-function movecontrib_civicrm_entityTypes(&$entityTypes) {
 }


### PR DESCRIPTION
Re-run latest civix - note this is just a housekeeping update - I always make sure civix is at latest when I install an extension but the changes are not significant

FYI I tested the forms with Smarty3 & all good (I didn't expect an issue)

Note the smarty mixin tweak is what wound up in civix - the smarty mixin picks up that version or anything later - so it is functionally the same but
a) more consistent with core extensions and
b) it wouldn't run through until I made that change