### PR TITLE
Add weight to move contrib link

### DIFF
--- a/movecontrib.php
+++ b/movecontrib.php
@@ -31,10 +31,6 @@ function movecontrib_civicrm_enable() {
 }
 
 function movecontrib_civicrm_searchTasks($objectType, &$tasks) {
-  /*Civi::log()->debug('movecontrib_civicrm_searchTasks', array(
-    '$objectType' => $objectType,
-    '$tasks' => $tasks,
-  ));*/
 
   if ($objectType === 'contribution' && CRM_Core_Permission::check('allow Move Contribution')) {
     $tasks[] = [
@@ -47,6 +43,7 @@ function movecontrib_civicrm_searchTasks($objectType, &$tasks) {
       'name' => E::ts('Move Contribution'),
       'url' => 'civicrm/contribute/task?reset=1&task_item=move',
       'key' => 'move',
+      'weight' => 130,
     ];
   }
 }


### PR DESCRIPTION
This both respects the original placement & avoids notices @lcdservices it's probably worth tagging a release just because there will be notices in latest stable without this weight