### PR TITLE
Fix permission name to match check

### DIFF
--- a/movecontrib.php
+++ b/movecontrib.php
@@ -53,7 +53,7 @@ function movecontrib_civicrm_searchTasks($objectType, &$tasks) {
  * @param array $permissions
  */
 function movecontrib_civicrm_permission(&$permissions) {
-  $permissions['Move Contributions'] = [
+  $permissions['allow Move Contribution'] = [
     'label' => E::ts('CiviCRM: Allow Move Contributions'),
     'description' => E::ts('Allow Move Contribution')
    ];


### PR DESCRIPTION
The permission name was changed in the previous PR but the check was not changed. I opted to change the name back rather than change the check in the hopes that already-granted permissions with the old name would not be wiped out.