### PR TITLE
Fix exception references

### DIFF
--- a/CRM/LCD/MoveContrib/BAO/MoveContrib.php
+++ b/CRM/LCD/MoveContrib/BAO/MoveContrib.php
@@ -56,7 +56,7 @@ class CRM_LCD_MoveContrib_BAO_MoveContrib {
       try {
         CRM_Activity_BAO_Activity::create($activityParams);
       }
-      catch (CiviCRM_API3_Exception $e) {}
+      catch (CRM_Core_Exception $e) {}
 
       return TRUE;
     }

--- a/CRM/LCD/MoveContrib/Form/Task.php
+++ b/CRM/LCD/MoveContrib/Form/Task.php
@@ -90,7 +90,7 @@ class CRM_LCD_MoveContrib_Form_Task extends CRM_Contribute_Form_Task {
           'return' => 'contact_id',
         ]);
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
       }
 
       $params = [

--- a/CRM/LCD/MoveContrib/Upgrader.php
+++ b/CRM/LCD/MoveContrib/Upgrader.php
@@ -25,7 +25,7 @@ class CRM_LCD_MoveContrib_Upgrader extends CRM_Extension_Upgrader_Base {
         'weight' => 1000,
       ));
     }
-    catch (CRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       Civi::log()->error('CRM_LCD_MoveContrib_Upgrader install $e', $e);
     }
   }


### PR DESCRIPTION
Since 5.52 CRM_API3_Exception has been an alias of CRM_Core_Exception

The compatibility in info.xml is 5.60 - so it's OK to update this to the 'real' extension